### PR TITLE
Added endpoint for evaluating pine expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased] - 2022-02-13
 ### Added
-- API endpoint for building expressions: `/build`
-- API endpoint for evaluating expressions: `/eval`
+- API endpoint for building expressions: `POST /build`
+- API endpoint for evaluating expressions: `POST /eval`
 
 ### Deprecated
-- API endpoint for building sql expressions `/pine/build`. Use the new endpoint: `/build`.
+- API endpoint for building sql expressions `POST /pine/build`. Use the new endpoint: `POST /build`.
 
 ## [0.3.0] - 2022-02-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [0.3.0] - 2022-10-02
+## [Unreleased] - 2022-02-13
+### Added
+- API endpoint for building expressions: `/build`
+- API endpoint for evaluating expressions: `/eval`
+
+### Deprecated
+- API endpoint for building sql expressions `/pine/build`. Use the new endpoint: `/build`.
+
+## [0.3.0] - 2022-02-10
 ### Added
 - Support for Postgres
 

--- a/src/pine/core.clj
+++ b/src/pine/core.clj
@@ -25,9 +25,9 @@
 
 (defn pine-eval
   "Evalate an SQL query"
-  [adapter prepared]
+  [prepared]
   (let [query (prepared :query)
         params (prepared :params)
         args   (cons query params)]
-    (protocol/query adapter args)
+    (protocol/query @db/connection args)
     ))


### PR DESCRIPTION
Added endpoint for evaluating pine expressions: `POST /eval`
Also deprecated the old endpoint: `POST /pine/build` in favor of `POST /build`