### PR TITLE
feat: add structured GET /api/v1/connections response

### DIFF
--- a/src/pine/api.clj
+++ b/src/pine/api.clj
@@ -119,6 +119,12 @@
        {:connection-id ""
         :version version}})))
 
+(defn get-connections []
+  {:result
+   {:version version
+    :selected-connection-id @db/connection-id
+    :connections (connections/list-connections)}})
+
 (defn test-connection [id]
   (let [result (db/run-query id {:query "SELECT NOW();"})]
     {:connection-id id :time result}))
@@ -171,7 +177,7 @@
 (defroutes app-routes
   ;; connection management
   (GET "/api/v1/connection" [] (-> (get-connection) response))
-  (GET "/api/v1/connections" [] (-> @connections/pools response))
+  (GET "/api/v1/connections" [] (-> (get-connections) response))
   (POST "/api/v1/connections" req
     (let [connection (get-in req [:params])]
       (-> {:connection-id (connections/add-connection-pool connection)} response)))

--- a/src/pine/db/connections.clj
+++ b/src/pine/db/connections.clj
@@ -39,8 +39,23 @@
 (defn make-connection-id [pool]
   (-> pool .getJdbcUrl (s/split #"/") (nth 2)))
 
+(defn jdbc-url->label [url]
+  (let [parts (s/split url #"/")
+        host-port (nth parts 2)
+        dbname (nth parts 3)]
+    (str host-port " · " dbname)))
+
+(defn make-connection-label [pool]
+  (jdbc-url->label (.getJdbcUrl pool)))
+
 (defn get-connection-name [id]
   (-> id get-connection-pool make-connection-id))
+
+(defn list-connections []
+  (mapv (fn [[id _]]
+          {:id id
+           :label (make-connection-label (get-connection-pool id))})
+        @pools))
 
 (defn add-connection-pool [connection]
   (let [pool (create-pool connection)


### PR DESCRIPTION
## Related PR
https://github.com/beamlynx/beamlynx-ui/pull/29

## Summary

Replaces the raw `GET /api/v1/connections` response with a structured payload the UI can use to list live database connections, show human-readable labels, and know which connection Pine currently has selected.

## Changes

### API — `GET /api/v1/connections`

Response shape (wrapped in `result`, consistent with `GET /api/v1/connection`):

```json
{
  "result": {
    "version": "0.35.0",
    "selected-connection-id": "localhost:5432",
    "connections": [
      {
        "id": "localhost:5432",
        "label": "localhost:5432 · myapp_dev"
      }
    ]
  }
}
```

- **`selected-connection-id`** — value of `@db/connection-id` (Pine’s currently selected connection), or `null` when no connection is selected.
- **`connections`** — all registered connection pools.
- **`id`** — existing connection handle (`host:port`), unchanged from prior behavior.
- **`label`** — display string `{host}:{port} · {dbname}`, derived from the pool JDBC URL.

## API surface

**Only change to an existing route:** `GET /api/v1/connections` — same path, **new response shape** (was raw `@pools` map; now structured `result` as above).

`docker/init-pine.sh` calls it once for debug logging and does not parse the body.
