### PR TITLE
Release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [0.36.0] - 2026-05-21
 ### Added
-- Structured `GET /api/v1/connections` response: returns an object with `version`, `selected-connection-id`, and a `connections` list of `{id, label}` entries (where `label` is formatted as `host:port · dbname`).
+- Structured `GET /api/v1/connections` response: returns an object with `version`, `selected-connection-id`, and a `connections` list of `{id, label}` entries (where `label` is formatted as `host:port · dbname`) (by @Koziar).
 
 ## [0.35.0] - 2026-05-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-05-21
+### Added
+- Structured `GET /api/v1/connections` response: returns an object with `version`, `selected-connection-id`, and a `connections` list of `{id, label}` entries (where `label` is formatted as `host:port · dbname`).
+
 ## [0.35.0] - 2026-05-05
 ### Added
 - Per-session database connections: `build`, `eval`, and `sql` endpoints now accept an optional `connection-id` parameter. Queries run against that specific connection pool; when absent, the global connection is used (backward compatible).

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.35.0
+    image: ahmadnazir/pine:0.36.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.35.0")
+(def version "0.36.0")


### PR DESCRIPTION
Adds a structured response to `GET /api/v1/connections` (by @Koziar). Previously the endpoint returned raw connection pool objects; now it returns a proper JSON object with `version`, `selected-connection-id`, and a `connections` list where each entry has an `id` and a human-readable `label` formatted as `host:port · dbname`.

Required by beamlynx-ui 0.43.0 for the connection picker.