### PR TITLE
Release 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,13 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.37.0] - 2026-07-31
 ### Added
-- Variables: name and reuse an intermediate query result across expressions with `|= name`. The API now accepts a list of expressions (`{"expressions": [...]}`), with variables assigned in earlier ones available in later ones:
-```
-company | where: active = true |= active_companies
-active_companies | employee | s: name
-```
-- Variable and checkpoint (`group:`/`limit:`) results emit as CTEs, flattened into a single top-level `WITH` clause, so e.g. `company | l: 10 | employee` composes correctly instead of producing malformed SQL. Joins through a variable resolve using the real table(s) it traces back to; two variables (or a variable and its source table) sharing the same underlying table join via a synthesized `id = id` join.
-- Join hints (`ast.hints.table[]`) carry a `resolution` field (`fk`, `heuristic`, `synthetic`, `manual`) and expose both join columns, distinguishing confirmed relationships from guessed ones.
-- Alias-dot partial syntax (`t.na`) is supported in all partial operations, not just complete ones.
+- Variables: name and reuse an intermediate query result across expressions with `|= name` (e.g. `company | where: active = true |= active_companies`). Results — including auto-sealed `group:`/`limit:` checkpoints — compile to CTEs, joins through a variable resolve using the real table(s) it traces back to, and a variable name can be used as a column qualifier (`x.col`) anywhere, including mid-expression.
 - `DELETE /api/v1/connections/:id` closes and removes a database connection pool.
 
 ### Fixed
-- An aliased `id` column selected through a variable now carries the alias through downstream joins; column renaming is table-scoped.
-- Auto-generated checkpoint CTE names are unique across an entire session, not just within a single expression.
-- Autocomplete no longer breaks when the cursor sits in the whitespace before a continuation line's `|`.
 - Pressing Tab on an empty expression now shows all tables instead of nothing.
 
 ## [0.36.0] - 2026-05-21

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.36.0
+    image: ahmadnazir/pine:0.37.0
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.36.0")
+(def version "0.37.0")


### PR DESCRIPTION
## Summary
Pine variables: name and reuse an intermediate query result across expressions with `|= name`. Results — including auto-sealed `group:`/`limit:` checkpoints — compile to CTEs, joins through a variable resolve using the real table(s) it traces back to, and a variable can be used as a column qualifier anywhere. Also adds `DELETE /api/v1/connections/:id` to close and remove a connection pool, and fixes Tab-autocomplete on an empty expression to list all tables instead of nothing.

## Test plan
- [ ] `lein test` / `clj -M:test` passes in CI
- [ ] Sanity-check `|= name` assignment and reuse, including through a checkpoint, against a real database
- [ ] Sanity-check `DELETE /api/v1/connections/:id`
- [ ] Press Tab on an empty expression and confirm it lists all tables