### PR TITLE
Release 0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.37.1] - 2026-08-02
 ### Fixed
 - The grammar (`pine.bnf`) now loads from the classpath instead of a `user.dir`-relative path, so the server no longer depends on being launched from the project root/a specific working directory.
 

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.37.0
+    image: ahmadnazir/pine:0.37.1
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.37.0")
+(def version "0.37.1")


### PR DESCRIPTION
Grammar loading no longer depends on the working directory it's launched from -- it now loads from the classpath instead of a `user.dir`-relative path.

## Test plan
- [x] `clj -M:fmt fix` clean
- [x] `./scripts/check-version-sync.sh` passes