### PR TITLE
Release 0.37.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.37.2] - 2026-08-04
+### Fixed
+- Relation/join hints for a column like `tenant_id` were lost whenever a checkpoint (`l:`/`group:`) sealed the selection into an anonymous CTE and `id` wasn't also selected — even though that relation never needed `id` in the first place. Only the synthetic self-join hint actually needs `id` to be selected; other relations no longer require it.
+- `POST /api/v1/connections` now returns a normal `{"error": "..."}` response instead of an uncaught server error when the target database is unreachable (e.g. down, wrong host/port).
+
 ## [0.37.1] - 2026-08-02
 ### Fixed
 - The grammar (`pine.bnf`) now loads from the classpath instead of a `user.dir`-relative path, so the server no longer depends on being launched from the project root/a specific working directory.

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.37.1
+    image: ahmadnazir/pine:0.37.2
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.37.1")
+(def version "0.37.2")


### PR DESCRIPTION
Two fixes:

- Relation/join hints for a column like `tenant_id` were lost whenever a checkpoint (`l:`/`group:`) sealed the selection into an anonymous CTE and `id` wasn't also selected, even though that relation never needed `id` in the first place. Only the synthetic self-join actually needs it; other relations no longer require it.
- `POST /api/v1/connections` now returns a normal `{"error": "..."}` response instead of an uncaught server error when the target database is unreachable.