### PR TITLE
fix: checkpoint feeding a terminal GROUP dropped its own CTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- A checkpoint (named via `|=` or auto-named) feeding into a pipeline's terminal `group:` had its own CTE silently dropped from the generated SQL, leaving the group's wrapper CTE referencing a relation that was never defined.
 
 ## [0.37.2] - 2026-08-04
 ### Fixed

--- a/src/pine/eval.clj
+++ b/src/pine/eval.clj
@@ -245,21 +245,33 @@
      :group-by group-by}))
 
 (defn build-group-query [state]
-  (let [{:keys [index]} state
+  (let [{:keys [index tables aliases]} state
+        ;; A checkpoint/variable feeding into a terminal GROUP (e.g. `|= x |
+        ;; g: ...`) needs its own CTE emitted too -- this path used to skip
+        ;; collect-ctes entirely (unlike build-select-query, which already
+        ;; calls it), so the user-named CTE was never defined and the group's
+        ;; wrapper CTE (below) referenced it as a dangling bare relation.
+        ctes        (collect-ctes tables aliases)
+        cte-params  (mapcat #(nth % 2 nil) ctes)
+        cte-prefix  (when (seq ctes)
+                      (str (s/join ", " (map (fn [[name body _]]
+                                               (str (q name) " AS ( " body " )"))
+                                             ctes))
+                           ", "))
         cte-alias (str "x_" index)
         ;; Build inner query (base SELECT with non-aggregate columns)
         inner-query (build-inner-select-for-group state)
         ;; Build outer query (SELECT from CTE with aggregates and GROUP BY)
         {:keys [select group-by]} (build-outer-select-for-group cte-alias state)
         ;; Combine into CTE
-        query (str "WITH " (q cte-alias) " AS ( " inner-query " ) " select " " group-by)
+        query (str "WITH " cte-prefix (q cte-alias) " AS ( " inner-query " ) " select " " group-by)
         ;; Extract params from WHERE clause
         params (when (not-empty (:where state))
                  (->> (:where state)
                       (map (fn [[_alias _col _cast _operator value]] (if (coll? value) value [value])))
                       remove-symbols
                       flatten))]
-    {:query query :params params}))
+    {:query query :params (seq (concat cte-params params))}))
 
 (defn build-delete-query [state]
   (let [{:keys [delete current aliases]} state

--- a/test/pine/eval_test.clj
+++ b/test/pine/eval_test.clj
@@ -695,6 +695,22 @@
     (is (= "WITH \"__pine_0__\" AS ( SELECT \"c_0\".\"id\", COUNT(1) AS \"count\" FROM \"x\".\"company\" AS \"c_0\" GROUP BY \"c_0\".\"id\" ) SELECT \"__pine_0__\".\"id\" FROM \"__pine_0__\" AS \"__pine_0__\" LIMIT 250"
            (:query (generate "x.company | group: id => count | s: id")))))
 
+  (testing "Checkpoint feeding a terminal GROUP nests its own CTE (user-named via |=)"
+    ;; build-group-query is a separate rendering path from build-select-query
+    ;; and used to skip collect-ctes entirely, so a checkpoint's CTE was never
+    ;; emitted when the pipeline's *last* op was :group - the group's own
+    ;; wrapper CTE ended up referencing the checkpoint's name (e.g. "pg") as a
+    ;; bare relation that was never defined anywhere, a dangling reference
+    ;; that would fail at execution time.
+    (is (= {:query "WITH \"pg\" AS ( SELECT \"c_0\".* FROM \"x\".\"company\" AS \"c_0\" LIMIT 10 ), \"x_4\" AS ( SELECT \"pg\".\"name\" AS \"name\" FROM \"pg\" AS \"pg\" ) SELECT \"x_4\".\"name\", COUNT(1) AS \"count\" FROM \"x_4\" GROUP BY \"x_4\".\"name\""
+            :params nil}
+           (generate "x.company | l: 10 |= pg | s: name | g: name => count"))))
+
+  (testing "Checkpoint feeding a terminal GROUP nests its own CTE (auto-named, no |=)"
+    (is (= {:query "WITH \"__pine_0__\" AS ( SELECT \"c_0\".* FROM \"x\".\"company\" AS \"c_0\" LIMIT 10 ), \"x_3\" AS ( SELECT \"__pine_0__\".\"name\" AS \"name\" FROM \"__pine_0__\" AS \"__pine_0__\" ) SELECT \"x_3\".\"name\", COUNT(1) AS \"count\" FROM \"x_3\" GROUP BY \"x_3\".\"name\""
+            :params nil}
+           (generate "x.company | l: 10 | s: name | g: name => count"))))
+
   (testing "Auto-named checkpoints across separate expressions don't collide"
     ;; Each expression starts from a fresh state, so without a session-wide
     ;; count, two expressions that each auto-name exactly one checkpoint both


### PR DESCRIPTION
A checkpoint (named via `|=` or auto-named) that feeds into a pipeline's *last* op being a `group:` was silently dropped from the generated SQL. `build-group-query` is a separate rendering path from `build-select-query` and never called `collect-ctes`, so the checkpoint's CTE was never defined, leaving the group's own wrapper CTE referencing a dangling relation name.

Fixed by collecting and prepending the checkpoint CTEs in `build-group-query`, same as the select path already does.