### PR TITLE
Release 0.37.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This change
 log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.37.3] - 2026-08-09
 ### Fixed
 - A checkpoint (named via `|=` or auto-named) feeding into a pipeline's terminal `group:` had its own CTE silently dropped from the generated SQL, leaving the group's wrapper CTE referencing a relation that was never defined.
 

--- a/playground.docker-compose.yml
+++ b/playground.docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   pine:
-    image: ahmadnazir/pine:0.37.2
+    image: ahmadnazir/pine:0.37.3
     container_name: pine_server
     depends_on:
       sample-db-ecommerce:

--- a/src/pine/version.clj
+++ b/src/pine/version.clj
@@ -1,3 +1,3 @@
 (ns pine.version)
 
-(def version "0.37.2")
+(def version "0.37.3")


### PR DESCRIPTION
Fixes a checkpoint feeding a terminal `group:` op silently dropping its own CTE, producing SQL with a dangling relation reference.